### PR TITLE
open input devices with O_CLOEXEC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = 0.1
 
 CC      = gcc
 LIBS    = -lm
-CFLAGS  = -std=c99 -pedantic -Wall -Wextra -DVERSION=\"$(VERSION)\"
+CFLAGS  = -std=gnu99 -pedantic -Wall -Wextra -DVERSION=\"$(VERSION)\"
 LDFLAGS = $(LIBS)
 
 PREFIX    ?= /usr/local

--- a/shkd.c
+++ b/shkd.c
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
     int fd[num], sel_fd, max_fd = 0;
 
     for (unsigned int i = 0; i < num; i++) {
-        fd[i] = open(input_device[i], O_RDONLY);
+        fd[i] = open(input_device[i], O_RDONLY|O_CLOEXEC);
         if (fd[i] == -1)
             err("can't open input device %s\n", input_device[i]);
         else if (fd[i] > max_fd)


### PR DESCRIPTION
otherwise, spawned child processes will inherit the input device file descriptors, which is not intended

the C compiler must be invoked with GNU99 rather than C99 standard in order for O_CLOEXEC to be provided by fcntl.h